### PR TITLE
feat: headers validation

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -22,6 +22,10 @@ const params = {
 	id: z.coerce.number()
 };
 
+const headers = {
+	'x-header': z.string().uuid()
+};
+
 app.get(
 	'/:id',
 	authenticate as WeakRequestHandler,
@@ -33,7 +37,8 @@ app.get(
 		},
 		body,
 		query,
-		params
+		params,
+		headers
 	}),
 	(req, res) => {
 		const { name, age } = req.query;


### PR DESCRIPTION
Hi!

I was wondering if we could add headers validation into the set?

Created a draft, but ponder on two things
- empty object can't be made strict as some headers are always being attached to request, wonder is we should even use `z.passthrough()`
- is not typed - express handler does not have generic for headers to pass in, not sure if there a way around that?