### PR TITLE
fix: check if _query is a property instead of truthy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ const descriptor = Object.getOwnPropertyDescriptor(express.request, 'query');
 if (descriptor) {
 	Object.defineProperty(express.request, 'query', {
 		get(this: Request) {
-			if (this._query) return this._query;
+			if (this.hasOwnProperty('_query')) return this._query;
 			return descriptor?.get?.call(this);
 		},
 		set(this: Request, query: unknown) {


### PR DESCRIPTION
Fixes https://github.com/AngaBlue/express-zod-safe/issues/20